### PR TITLE
Add permission feature

### DIFF
--- a/DependencyInjection/Compiler/CheckPermissionsConsistencyPass.php
+++ b/DependencyInjection/Compiler/CheckPermissionsConsistencyPass.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: kevin
+ * Date: 21/11/16
+ * Time: 19:10
+ */
+
+namespace Quef\TeamBundle\DependencyInjection\Compiler;
+
+
+use Quef\TeamBundle\Metadata\Metadata;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class CheckPermissionsConsistencyPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter('quef.teams')) {
+            return;
+        }
+
+        $teamsConfiguration = $container->getParameter('quef.teams');
+
+        foreach ($teamsConfiguration as $alias => $teamConfiguration) {
+            $metadata  = new Metadata($alias, $teamConfiguration);
+
+            $this->ensurePermissionsDefinedInRolesExist($metadata);
+        }
+    }
+
+    public function ensurePermissionsDefinedInRolesExist(Metadata $metadata)
+    {
+        $alias = $metadata->getAlias();
+        $rolesConfiguration = $metadata->getRolesConfiguration();
+        $permissions = $metadata->getPermissions();
+
+        $rolesPermissions = array_unique(
+            array_values(
+                array_map(function($a) { return array_pop($a['permissions']); }, $rolesConfiguration)
+            )
+        );
+
+        if (!empty($permissionsNotFound = array_diff($rolesPermissions, $permissions))) {
+            throw new \InvalidArgumentException(
+                sprintf('The permissions %s defined in role permissions for team %s are not present in permissions list',
+                    print_r($permissionsNotFound, true), $alias));
+        }
+    }
+}

--- a/DependencyInjection/Compiler/RegisterTeamsPass.php
+++ b/DependencyInjection/Compiler/RegisterTeamsPass.php
@@ -13,6 +13,7 @@ use Quef\TeamBundle\Factory\InviteFactory;
 use Quef\TeamBundle\Factory\TeamMemberFactory;
 use Quef\TeamBundle\Metadata\Metadata;
 use Quef\TeamBundle\Metadata\MetadataInterface;
+use Quef\TeamBundle\Security\Permission\PermissionProvider;
 use Quef\TeamBundle\Security\Role\RoleChecker;
 use Quef\TeamBundle\Security\Role\RoleHierarchy;
 use Quef\TeamBundle\Security\Role\RoleProvider;
@@ -43,6 +44,7 @@ class RegisterTeamsPass implements CompilerPassInterface
             $this->addTeamProvider($container, $metadata);
             $this->addTeamMemberFactory($container, $metadata);
             $this->addInviteFactory($container, $metadata);
+            $this->addPermissionProvider($container, $metadata);
         }
     }
 
@@ -94,5 +96,11 @@ class RegisterTeamsPass implements CompilerPassInterface
         $definition = new Definition(TeamMemberFactory::class);
         $definition->addMethodCall('setClassName', [$metadata->getMember()]);
         $container->setDefinition($metadata->getServiceId('factory.member'), $definition);
+    }
+
+    private function addPermissionProvider(ContainerBuilder $container, MetadataInterface $metadata)
+    {
+        $definition = new Definition(PermissionProvider::class, [$metadata->getRolesConfiguration()]);
+        $container->setDefinition($metadata->getServiceId('provider.permission'), $definition);
     }
 }

--- a/DependencyInjection/Compiler/RegisterTeamsPass.php
+++ b/DependencyInjection/Compiler/RegisterTeamsPass.php
@@ -13,6 +13,7 @@ use Quef\TeamBundle\Factory\InviteFactory;
 use Quef\TeamBundle\Factory\TeamMemberFactory;
 use Quef\TeamBundle\Metadata\Metadata;
 use Quef\TeamBundle\Metadata\MetadataInterface;
+use Quef\TeamBundle\Security\Permission\PermissionChecker;
 use Quef\TeamBundle\Security\Permission\PermissionProvider;
 use Quef\TeamBundle\Security\Role\RoleChecker;
 use Quef\TeamBundle\Security\Role\RoleHierarchy;
@@ -45,6 +46,7 @@ class RegisterTeamsPass implements CompilerPassInterface
             $this->addTeamMemberFactory($container, $metadata);
             $this->addInviteFactory($container, $metadata);
             $this->addPermissionProvider($container, $metadata);
+            $this->addPermissionChecker($container, $metadata);
         }
     }
 
@@ -102,5 +104,13 @@ class RegisterTeamsPass implements CompilerPassInterface
     {
         $definition = new Definition(PermissionProvider::class, [$metadata->getRolesConfiguration()]);
         $container->setDefinition($metadata->getServiceId('provider.permission'), $definition);
+    }
+
+    private function addPermissionChecker(ContainerBuilder $container, MetadataInterface $metadata)
+    {
+        $definition = new Definition(PermissionChecker::class, [
+            new Reference($metadata->getServiceId('provider.permission'))
+        ] );
+        $container->setDefinition($metadata->getServiceId('checker.permission'), $definition);
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -35,6 +35,7 @@ class Configuration implements ConfigurationInterface
                             ->isRequired()
                             ->cannotBeEmpty()
                         ->end()
+                        ->append($this->addPermissionsNode())
                     ->end()
                 ->end()
             ->end()
@@ -127,6 +128,17 @@ class Configuration implements ConfigurationInterface
             ->prototype('array')
                 ->prototype('scalar')->end()
             ->end()
+        ->end();
+
+        return $node;
+    }
+
+    public function addPermissionsNode()
+    {
+        $node = new ArrayNodeDefinition('permissions');
+
+        $node
+            ->prototype('scalar')->end()
         ->end();
 
         return $node;

--- a/Exception/PermissionsNotFoundException.php
+++ b/Exception/PermissionsNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: kevin
+ * Date: 21/11/16
+ * Time: 17:16
+ */
+
+namespace Quef\TeamBundle\Exception;
+
+
+class PermissionsNotFoundException extends \RuntimeException
+{
+
+}

--- a/Metadata/Metadata.php
+++ b/Metadata/Metadata.php
@@ -85,4 +85,9 @@ class Metadata implements MetadataInterface
     {
         return sprintf('%s.%s', $this->getAlias(), $serviceName);
     }
+
+    public function getPermissions()
+    {
+        return $this->parameters['permissions'];
+    }
 }

--- a/Metadata/Metadata.php
+++ b/Metadata/Metadata.php
@@ -60,6 +60,11 @@ class Metadata implements MetadataInterface
 
     public function getRoles()
     {
+        return array_keys($this->parameters['roles']);
+    }
+
+    public function getRolesConfiguration()
+    {
         return $this->parameters['roles'];
     }
 

--- a/Metadata/MetadataInterface.php
+++ b/Metadata/MetadataInterface.php
@@ -62,4 +62,6 @@ interface MetadataInterface
      * @return string
      */
     public function getServiceId($serviceName);
+
+    public function getRolesConfiguration();
 }

--- a/Security/Permission/PermissionChecker.php
+++ b/Security/Permission/PermissionChecker.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Quef\TeamBundle\Security\Permission;
+
+class PermissionChecker implements PermissionCheckerInterface
+{
+    private $permissionProvider;
+
+    public function __construct(PermissionProviderInterface $permissionProvider)
+    {
+        $this->permissionProvider = $permissionProvider;
+    }
+
+    public function isAuthorized($role, $permission)
+    {
+        $permissions  = $this->permissionProvider->getPermissionsForRole($role);
+
+        if (in_array($permission, $permissions)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/Security/Permission/PermissionCheckerInterface.php
+++ b/Security/Permission/PermissionCheckerInterface.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: kevin
+ * Date: 21/11/16
+ * Time: 18:34
+ */
+
+namespace Quef\TeamBundle\Security\Permission;
+
+
+interface PermissionCheckerInterface
+{
+}

--- a/Security/Permission/PermissionProvider.php
+++ b/Security/Permission/PermissionProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Quef\TeamBundle\Security\Permission;
+
+use Quef\TeamBundle\Exception\PermissionsNotFoundException;
+
+class PermissionProvider implements PermissionProviderInterface
+{
+    private $rolesConfiguration;
+
+    public function __construct($rolesConfiguration)
+    {
+        $this->rolesConfiguration = $rolesConfiguration;
+    }
+
+    public function getPermissionsForRole($role)
+    {
+        if (!is_string($role)) {
+            throw new \InvalidArgumentException('The role should be a string parameter');
+        }
+
+        if (!isset($this->rolesConfiguration[$role])) {
+            throw new PermissionsNotFoundException(
+                sprintf('The role %s is not defined in the roles configuration', $role));
+        }
+
+        return $this->rolesConfiguration[$role]['permissions'];
+    }
+}

--- a/Security/Permission/PermissionProviderInterface.php
+++ b/Security/Permission/PermissionProviderInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Quef\TeamBundle\Security\Permission;
+
+interface PermissionProviderInterface
+{
+    public function getPermissionsForRole($role);
+}

--- a/Tests/DependencyInjection/Compiler/CheckPermissionsConsistencyPassCheckTest.php
+++ b/Tests/DependencyInjection/Compiler/CheckPermissionsConsistencyPassCheckTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Quef\TeamBundle\Tests\DependencyInjection\Compiler;
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Quef\TeamBundle\DependencyInjection\Compiler\CheckPermissionConsistencyPass;
+use Quef\TeamBundle\DependencyInjection\Compiler\CheckPermissionsConsistencyPass;
+use Quef\TeamBundle\DependencyInjection\Compiler\CheckRolesConsistencyPass;
+use Quef\TeamBundle\DependencyInjection\Compiler\RegisterTeamsPass;
+use Quef\TeamBundle\DependencyInjection\Configuration;
+use Quef\TeamBundle\DependencyInjection\QuefTeamExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class CheckPermissionsConsistencyPassCheckTest extends AbstractCompilerPassTestCase
+{
+    public function registerCompilerPass(ContainerBuilder $container)
+    {
+        $this->container->addCompilerPass(new RegisterTeamsPass());
+        $this->container->addCompilerPass(new CheckPermissionsConsistencyPass($container));
+    }
+
+    public function testPermissionsAssociatedToRoleButNotDefinedInPermissionListThrowException()
+    {
+        $configs = [
+            [
+                'teams' => [
+                    'team1' => [
+                        'team' => 'Quef\Bundle\TeamTest',
+                        'member' => 'Quef\Bundle\MemberTest',
+                        'invite' => 'Quef\Bundle\InviteTest',
+                        'roles' => [
+                            'role1' => [
+                                'permissions' => [
+                                    'read'
+                                ]
+                            ],
+                            'role3' => [
+                                'permissions' => [
+                                    'update'
+                                ]
+                            ]
+                        ],
+                        'admin_role' => 'role1',
+                        'permissions' => [
+                            'create'
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $extension = new QuefTeamExtension();
+        $extension->load($configs, $this->container);
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->container->compile();
+    }
+
+}

--- a/Tests/DependencyInjection/Compiler/RegisterTeamsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/RegisterTeamsPassTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: kevin
+ * Date: 21/11/16
+ * Time: 17:36
+ */
+
+namespace Quef\TeamBundle\Tests\DependencyInjection\Compiler;
+
+
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
+use Quef\TeamBundle\DependencyInjection\Compiler\RegisterTeamsPass;
+use Quef\TeamBundle\DependencyInjection\QuefTeamExtension;
+use Quef\TeamBundle\Security\Permission\PermissionProvider;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class RegisterTeamsPassTest extends AbstractCompilerPassTestCase
+{
+    public function registerCompilerPass(ContainerBuilder $container)
+    {
+        $this->container->addCompilerPass(new RegisterTeamsPass());
+    }
+
+    public function testOnePermissionProviderIsRegisteredForEachTeam()
+    {
+        $configs = [
+            [
+                'teams' => [
+                    'team1' => [
+                        'team' => 'Quef\Bundle\TeamTest',
+                        'member' => 'Quef\Bundle\MemberTest',
+                        'invite' => 'Quef\Bundle\InviteTest',
+                        'roles' => [
+                            'role1' => [
+                                'permissions' => ['create', 'read', 'update']
+                            ]
+                        ],
+                        'admin_role' => 'admin_role'
+                    ],
+                    'team2' => [
+                        'team' => 'Quef\Bundle\TeamTest',
+                        'member' => 'Quef\Bundle\MemberTest',
+                        'invite' => 'Quef\Bundle\InviteTest',
+                        'roles' => [
+                            'role1' => [
+                                'permissions' => ['read', 'update']
+                            ]
+                        ],
+                        'admin_role' => 'admin_role'
+                    ],
+                ]
+            ]
+        ];
+
+        $extension = new QuefTeamExtension();
+        $extension->load($configs, $this->container);
+
+        $this->container->compile();
+
+        $roleConfigurationForTeam1 = ['role1' => ['permissions' => ['create', 'read', 'update']]];
+        $roleConfigurationForTeam2 = ['role1' => ['permissions' => ['read', 'update']]];
+
+        $this->assertContainerBuilderHasService('team1.provider.permission', PermissionProvider::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('team1.provider.permission', 0, $roleConfigurationForTeam1);
+
+        $this->assertContainerBuilderHasService('team2.provider.permission', PermissionProvider::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('team2.provider.permission', 0, $roleConfigurationForTeam2);
+    }
+}

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -214,6 +214,97 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testPermissionsCanBeDefinedForRole()
+    {
+        $this->assertConfigurationIsValid(
+            [
+                [
+                    'teams' => [
+                        'team1' => [
+                            'roles' => [
+                                'role1' => [
+                                    'permissions' => [
+                                        'permission1',
+                                        'permission2'
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'teams.*.roles.*.permissions'
+        );
+    }
+
+    public function testRoleNameIsUsedAsKeyInRolesNode()
+    {
+        $this->assertProcessedConfigurationEquals(
+            [
+                [
+                    'teams' => [
+                        'team1' => [
+                            'roles' => [
+                                ['name' => 'role1']
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'teams' => [
+                    'team1' => [
+                        'roles' => [
+                            'role1' => [
+                                'permissions' => []
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'teams.*.roles.*'
+        );
+    }
+
+    public function testRoleCanBeDefinedWithoutPermissions()
+    {
+        $this->assertProcessedConfigurationEquals(
+            [
+                [
+                    'teams' => [
+                        'team1' => [
+                            'roles' => [
+                                'role1',
+                                'role2' => [
+                                    'permissions' => [
+                                        'permission1'
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            [
+                'teams' => [
+                    'team1' => [
+                        'roles' => [
+                            'role1' => [
+                                'permissions' => []
+                            ],
+                            'role2' => [
+                                'permissions' => [
+                                    'permission1'
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'teams.*.roles'
+        );
+    }
+
     public function testScalarPermissionsCanBeDefined()
     {
         $this->assertConfigurationIsValid(

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -213,4 +213,39 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
             "teams.*.roles"
         );
     }
+
+    public function testScalarPermissionsCanBeDefined()
+    {
+        $this->assertConfigurationIsValid(
+            [
+                [
+                    'teams' => [
+                        'team1' => [
+                            'permissions' => [
+                                'permission1',
+                                'permission2'
+                            ]
+                        ]
+                    ]
+                ]
+            ],
+            'teams.*.permissions'
+        );
+    }
+
+    public function testPermissionsCanBeEmpty()
+    {
+        $this->assertConfigurationIsValid(
+            [
+                [
+                    'teams' => [
+                        'team1' => [
+                            'permissions' => []
+                        ]
+                    ]
+                ]
+            ],
+            'teams.*.permissions'
+        );
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
     "matthiasnoback/symfony-config-test": "^2.0",
     "phpunit/phpunit": "^5.6",
     "matthiasnoback/symfony-dependency-injection-test": "^1.0",
-    "phpspec/phpspec": "^3.1"
+    "phpspec/phpspec": "^3.1",
+    "symfony/var-dumper": "^3.1"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
   "require-dev": {
     "matthiasnoback/symfony-config-test": "^2.0",
     "phpunit/phpunit": "^5.6",
-    "matthiasnoback/symfony-dependency-injection-test": "^1.0"
+    "matthiasnoback/symfony-dependency-injection-test": "^1.0",
+    "phpspec/phpspec": "^3.1"
   }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "cbffe412355fdc7d326fefbb75177140",
-    "content-hash": "8f7d7695deba6286d2af521dd267c5ee",
+    "hash": "9674a0494338fbfdcce897dcbc1c804b",
+    "content-hash": "6c46a2bbe3e182b9ca97292855d78868",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -856,16 +856,16 @@
         },
         {
             "name": "symfony/config",
-            "version": "v2.8.13",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "f8b1922bbda9d2ac86aecd649399040bce849fde"
+                "reference": "1361bc4e66f97b6202ae83f4190e962c624b5e61"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/f8b1922bbda9d2ac86aecd649399040bce849fde",
-                "reference": "f8b1922bbda9d2ac86aecd649399040bce849fde",
+                "url": "https://api.github.com/repos/symfony/config/zipball/1361bc4e66f97b6202ae83f4190e962c624b5e61",
+                "reference": "1361bc4e66f97b6202ae83f4190e962c624b5e61",
                 "shasum": ""
             },
             "require": {
@@ -905,20 +905,20 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-14 20:31:12"
+            "time": "2016-11-03 07:52:58"
         },
         {
             "name": "symfony/console",
-            "version": "v3.1.6",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "c99da1119ae61e15de0e4829196b9fba6f73d065"
+                "reference": "5be36e1f3ac7ecbe7e34fb641480ad8497b83aa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/c99da1119ae61e15de0e4829196b9fba6f73d065",
-                "reference": "c99da1119ae61e15de0e4829196b9fba6f73d065",
+                "url": "https://api.github.com/repos/symfony/console/zipball/5be36e1f3ac7ecbe7e34fb641480ad8497b83aa6",
+                "reference": "5be36e1f3ac7ecbe7e34fb641480ad8497b83aa6",
                 "shasum": ""
             },
             "require": {
@@ -966,20 +966,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-06 01:44:51"
+            "time": "2016-11-16 22:17:09"
         },
         {
             "name": "symfony/debug",
-            "version": "v2.8.13",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "8c29235936a47473af16fb91c7c4b7b193c5693c"
+                "reference": "62a68f640456f6761d752c62d81631428ef0d8a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/8c29235936a47473af16fb91c7c4b7b193c5693c",
-                "reference": "8c29235936a47473af16fb91c7c4b7b193c5693c",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/62a68f640456f6761d752c62d81631428ef0d8a1",
+                "reference": "62a68f640456f6761d752c62d81631428ef0d8a1",
                 "shasum": ""
             },
             "require": {
@@ -1023,20 +1023,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2016-09-06 10:55:00"
+            "time": "2016-11-15 12:53:17"
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v2.8.13",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "3d61c765daa1a5832f1d7c767f48886b8d8ea64c"
+                "reference": "9d2c5033ca70ceade8d7584f997a9d3943f0fe5f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/3d61c765daa1a5832f1d7c767f48886b8d8ea64c",
-                "reference": "3d61c765daa1a5832f1d7c767f48886b8d8ea64c",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/9d2c5033ca70ceade8d7584f997a9d3943f0fe5f",
+                "reference": "9d2c5033ca70ceade8d7584f997a9d3943f0fe5f",
                 "shasum": ""
             },
             "require": {
@@ -1086,7 +1086,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-24 15:52:36"
+            "time": "2016-11-18 21:10:01"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -2120,16 +2120,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v2.8.13",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "cca6ff892355876534b01a927f789bac9601c935"
+                "reference": "edbe67e8f729885b55421d5cc58223d48540df07"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/cca6ff892355876534b01a927f789bac9601c935",
-                "reference": "cca6ff892355876534b01a927f789bac9601c935",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/edbe67e8f729885b55421d5cc58223d48540df07",
+                "reference": "edbe67e8f729885b55421d5cc58223d48540df07",
                 "shasum": ""
             },
             "require": {
@@ -2180,7 +2180,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-18 04:28:30"
+            "time": "2016-11-18 21:10:01"
         }
     ],
     "packages-dev": [
@@ -2469,6 +2469,126 @@
                 }
             ],
             "time": "2016-06-10 07:14:17"
+        },
+        {
+            "name": "phpspec/php-diff",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/php-diff.git",
+                "reference": "0464787bfa7cd13576c5a1e318709768798bec6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/php-diff/zipball/0464787bfa7cd13576c5a1e318709768798bec6a",
+                "reference": "0464787bfa7cd13576c5a1e318709768798bec6a",
+                "shasum": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Diff": "lib/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Boulton",
+                    "homepage": "http://github.com/chrisboulton"
+                }
+            ],
+            "description": "A comprehensive library for generating differences between two hashable objects (strings or arrays).",
+            "time": "2016-04-07 12:29:16"
+        },
+        {
+            "name": "phpspec/phpspec",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/phpspec.git",
+                "reference": "53d89ff6d328032c0e434a75af6b0e80ff2d669d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/phpspec/zipball/53d89ff6d328032c0e434a75af6b0e80ff2d669d",
+                "reference": "53d89ff6d328032c0e434a75af6b0e80ff2d669d",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/instantiator": "^1.0.1",
+                "ext-tokenizer": "*",
+                "php": "^5.6 || ^7.0",
+                "phpspec/php-diff": "^1.0.0",
+                "phpspec/prophecy": "^1.5",
+                "sebastian/exporter": "^1.0",
+                "symfony/console": "^2.7 || ^3.0",
+                "symfony/event-dispatcher": "^2.7 || ^3.0",
+                "symfony/finder": "^2.7 || ^3.0",
+                "symfony/process": "^2.7 || ^3.0",
+                "symfony/yaml": "^2.7 || ^3.0"
+            },
+            "require-dev": {
+                "behat/behat": "^3.1",
+                "ciaranmcnulty/versionbasedtestskipper": "^0.2.1",
+                "phpunit/phpunit": "^5.4",
+                "symfony/filesystem": "^3.0"
+            },
+            "suggest": {
+                "phpspec/nyan-formatters": "~1.0 – Adds Nyan formatters"
+            },
+            "bin": [
+                "bin/phpspec"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "PhpSpec": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com",
+                    "homepage": "http://everzet.com"
+                },
+                {
+                    "name": "Marcello Duarte",
+                    "homepage": "http://marcelloduarte.net/"
+                },
+                {
+                    "name": "Ciaran McNulty",
+                    "homepage": "https://ciaranmcnulty.com/"
+                }
+            ],
+            "description": "Specification-oriented BDD framework for PHP 5.6+",
+            "homepage": "http://phpspec.net/",
+            "keywords": [
+                "BDD",
+                "SpecBDD",
+                "TDD",
+                "spec",
+                "specification",
+                "testing",
+                "tests"
+            ],
+            "time": "2016-09-26 21:11:31"
         },
         {
             "name": "phpspec/prophecy",
@@ -3431,17 +3551,66 @@
             "time": "2016-02-04 12:56:52"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.1.6",
+            "name": "symfony/process",
+            "version": "v3.1.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27"
+                "url": "https://github.com/symfony/process.git",
+                "reference": "66de154ae86b1a07001da9fbffd620206e4faf94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/7ff51b06c6c3d5cc6686df69004a42c69df09e27",
-                "reference": "7ff51b06c6c3d5cc6686df69004a42c69df09e27",
+                "url": "https://api.github.com/repos/symfony/process/zipball/66de154ae86b1a07001da9fbffd620206e4faf94",
+                "reference": "66de154ae86b1a07001da9fbffd620206e4faf94",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Process\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Process Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-09-29 14:13:09"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v3.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "9da375317228e54f4ea1b013b30fa47417e84943"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/9da375317228e54f4ea1b013b30fa47417e84943",
+                "reference": "9da375317228e54f4ea1b013b30fa47417e84943",
                 "shasum": ""
             },
             "require": {
@@ -3477,7 +3646,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2016-10-24 18:41:13"
+            "time": "2016-11-18 21:05:29"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "9674a0494338fbfdcce897dcbc1c804b",
-    "content-hash": "6c46a2bbe3e182b9ca97292855d78868",
+    "hash": "4e2aa151f34e6669db88fc619c67f1e4",
+    "content-hash": "f4575f83b8a2286c91425d5c5857ed72",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -3598,6 +3598,69 @@
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
             "time": "2016-09-29 14:13:09"
+        },
+        {
+            "name": "symfony/var-dumper",
+            "version": "v3.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-dumper.git",
+                "reference": "0c2d613e890e33f4da810159ac97931068f5bd17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/0c2d613e890e33f4da810159ac97931068f5bd17",
+                "reference": "0c2d613e890e33f4da810159ac97931068f5bd17",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "twig/twig": "~1.20|~2.0"
+            },
+            "suggest": {
+                "ext-symfony_debug": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.1-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Resources/functions/dump.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Component\\VarDumper\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony mechanism for exploring and dumping PHP variables",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "debug",
+                "dump"
+            ],
+            "time": "2016-11-03 08:04:31"
         },
         {
             "name": "symfony/yaml",

--- a/phpspec.yml
+++ b/phpspec.yml
@@ -1,0 +1,6 @@
+suites:
+    default:
+        namespace: Quef\TeamBundle
+        psr4_prefix: Quef\TeamBundle
+        src_path: %paths.config%
+        spec_path: %paths.config%

--- a/spec/Security/Permission/PermissionCheckerSpec.php
+++ b/spec/Security/Permission/PermissionCheckerSpec.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace spec\Quef\TeamBundle\Security\Permission;
+
+use Quef\TeamBundle\Security\Permission\PermissionChecker;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Quef\TeamBundle\Security\Permission\PermissionCheckerInterface;
+use Quef\TeamBundle\Security\Permission\PermissionProviderInterface;
+
+class PermissionCheckerSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PermissionChecker::class);
+        $this->shouldImplement(PermissionCheckerInterface::class);
+    }
+
+    function let(
+        PermissionProviderInterface $permissionProvider
+    ) {
+        $this->beConstructedWith($permissionProvider);
+    }
+
+    function it_authorizes_a_role_if_a_permission_is_defined_for_the_given_a_role(
+        PermissionProviderInterface $permissionProvider
+    ) {
+        $role = 'role1';
+        $permission = 'read';
+
+        $permissionProvider->getPermissionsForRole(Argument::type('string'))->willReturn(['read', 'update']);
+
+        $this->isAuthorized($role, $permission)->shouldReturn(true);
+    }
+
+    function it_denies_a_role_if_a_permission_is_not_defined_for_the_given_role(
+        PermissionProviderInterface $permissionProvider
+    ) {
+        $role = 'role1';
+        $permission = 'create';
+
+        $permissionProvider->getPermissionsForRole(Argument::type('string'))->willReturn(['read', 'update']);
+
+        $this->isAuthorized($role, $permission)->shouldReturn(false);
+    }
+}

--- a/spec/Security/Permission/PermissionProviderSpec.php
+++ b/spec/Security/Permission/PermissionProviderSpec.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace spec\Quef\TeamBundle\Security\Permission;
+
+use Quef\TeamBundle\Exception\PermissionsNotFoundException;
+use Quef\TeamBundle\Security\Permission\PermissionProvider;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Quef\TeamBundle\Security\Permission\PermissionProviderInterface;
+
+class PermissionProviderSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(PermissionProvider::class);
+        $this->shouldImplement(PermissionProviderInterface::class);
+    }
+
+    function let()
+    {
+        $roleConfiguration = [
+            'role1' => [
+                'permissions' => [
+                    'permission1',
+                    'permission2'
+                ]
+            ],
+            'role2' => [
+                'permissions' => [
+                    'permission3',
+                    'permission4'
+                ]
+            ]
+        ];
+
+        $this->beConstructedWith($roleConfiguration);
+    }
+
+    function it_provides_permission_for_a_given_role()
+    {
+        $resultForRole1 = ['permission1', 'permission2'];
+        $resultForRole2 = ['permission3', 'permission4'];
+
+        $this->getPermissionsForRole('role1')->shouldReturn($resultForRole1);
+        $this->getPermissionsForRole('role2')->shouldReturn($resultForRole2);
+    }
+
+    function it_throws_exception_when_trying_to_get_permissions_for_inexistent_role()
+    {
+        $this->shouldThrow(PermissionsNotFoundException::class)->during('getPermissionsForRole', ['role3']);
+    }
+}


### PR DESCRIPTION
This PR will add the ability to define a set of permissions for each role in the configuration.
The permissions defined in a role must be previously defined in the global permission set.

For instance: 
```yml
teams:
    team1:
        roles:
            consultant:
                permissions:
                    - create
                    - read
        permissions:
            - create
            - read
````

It adds two services for each team : 
- a permission provider to enable us to retrieve the list of permissions for a given role
- a permission checker to enable us to check if a given role is authorized for a specific permission