### PR TITLE
Add a service to check the permissions of a team member

### DIFF
--- a/DependencyInjection/Compiler/RegisterTeamsPass.php
+++ b/DependencyInjection/Compiler/RegisterTeamsPass.php
@@ -13,8 +13,9 @@ use Quef\TeamBundle\Factory\InviteFactory;
 use Quef\TeamBundle\Factory\TeamMemberFactory;
 use Quef\TeamBundle\Metadata\Metadata;
 use Quef\TeamBundle\Metadata\MetadataInterface;
-use Quef\TeamBundle\Security\Permission\PermissionChecker;
 use Quef\TeamBundle\Security\Permission\PermissionProvider;
+use Quef\TeamBundle\Security\Permission\RolePermissionChecker;
+use Quef\TeamBundle\Security\Permission\TeamMemberPermissionChecker;
 use Quef\TeamBundle\Security\Role\RoleChecker;
 use Quef\TeamBundle\Security\Role\RoleHierarchy;
 use Quef\TeamBundle\Security\Role\RoleProvider;
@@ -46,7 +47,8 @@ class RegisterTeamsPass implements CompilerPassInterface
             $this->addTeamMemberFactory($container, $metadata);
             $this->addInviteFactory($container, $metadata);
             $this->addPermissionProvider($container, $metadata);
-            $this->addPermissionChecker($container, $metadata);
+            $this->addRolePermissionChecker($container, $metadata);
+            $this->addTeamMemberPermissionChecker($container, $metadata);
         }
     }
 
@@ -106,11 +108,19 @@ class RegisterTeamsPass implements CompilerPassInterface
         $container->setDefinition($metadata->getServiceId('provider.permission'), $definition);
     }
 
-    private function addPermissionChecker(ContainerBuilder $container, MetadataInterface $metadata)
+    private function addRolePermissionChecker(ContainerBuilder $container, MetadataInterface $metadata)
     {
-        $definition = new Definition(PermissionChecker::class, [
+        $definition = new Definition(RolePermissionChecker::class, [
             new Reference($metadata->getServiceId('provider.permission'))
         ] );
-        $container->setDefinition($metadata->getServiceId('checker.permission'), $definition);
+        $container->setDefinition($metadata->getServiceId('checker.role_permission'), $definition);
+    }
+
+    private function addTeamMemberPermissionChecker(ContainerBuilder $container, MetadataInterface $metadata)
+    {
+        $definition = new Definition(TeamMemberPermissionChecker::class, [
+            new Reference($metadata->getServiceId('checker.role_permission'))
+        ] );
+        $container->setDefinition($metadata->getServiceId('checker.team_member_permission'), $definition);
     }
 }

--- a/Security/Permission/RolePermissionChecker.php
+++ b/Security/Permission/RolePermissionChecker.php
@@ -2,7 +2,7 @@
 
 namespace Quef\TeamBundle\Security\Permission;
 
-class PermissionChecker implements PermissionCheckerInterface
+class RolePermissionChecker implements RolePermissionCheckerInterface
 {
     private $permissionProvider;
 

--- a/Security/Permission/RolePermissionCheckerInterface.php
+++ b/Security/Permission/RolePermissionCheckerInterface.php
@@ -9,6 +9,7 @@
 namespace Quef\TeamBundle\Security\Permission;
 
 
-interface PermissionCheckerInterface
+interface RolePermissionCheckerInterface
 {
+    public function isAuthorized($role, $permission);
 }

--- a/Security/Permission/TeamMemberPermissionChecker.php
+++ b/Security/Permission/TeamMemberPermissionChecker.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Quef\TeamBundle\Security\Permission;
+
+use Quef\TeamBundle\Model\TeamMemberInterface;
+
+class TeamMemberPermissionChecker implements TeamMemberPermissionCheckerInterface
+{
+    private $rolePermissionChecker;
+
+    public function __construct(
+        RolePermissionCheckerInterface $rolePermissionChecker
+    ) {
+        $this->rolePermissionChecker = $rolePermissionChecker;
+    }
+
+    public function isAuthorized(TeamMemberInterface $teamMember, $permission)
+    {
+        $role = $teamMember->getTeamRole();
+
+        return $this->rolePermissionChecker->isAuthorized($role, $permission);
+    }
+}

--- a/Security/Permission/TeamMemberPermissionCheckerInterface.php
+++ b/Security/Permission/TeamMemberPermissionCheckerInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Quef\TeamBundle\Security\Permission;
+
+use Quef\TeamBundle\Model\TeamMemberInterface;
+
+interface TeamMemberPermissionCheckerInterface
+{
+    public function isAuthorized(TeamMemberInterface $teamMember, $permission);
+}

--- a/Tests/DependencyInjection/Compiler/RegisterTeamsPassTest.php
+++ b/Tests/DependencyInjection/Compiler/RegisterTeamsPassTest.php
@@ -12,8 +12,9 @@ namespace Quef\TeamBundle\Tests\DependencyInjection\Compiler;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractCompilerPassTestCase;
 use Quef\TeamBundle\DependencyInjection\Compiler\RegisterTeamsPass;
 use Quef\TeamBundle\DependencyInjection\QuefTeamExtension;
-use Quef\TeamBundle\Security\Permission\PermissionChecker;
 use Quef\TeamBundle\Security\Permission\PermissionProvider;
+use Quef\TeamBundle\Security\Permission\RolePermissionChecker;
+use Quef\TeamBundle\Security\Permission\TeamMemberPermissionChecker;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Reference;
 
@@ -76,17 +77,31 @@ class RegisterTeamsPassTest extends AbstractCompilerPassTestCase
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('team2.provider.permission', 0, $roleConfigurationForTeam2);
     }
 
-    public function testOnePermissionCheckerIsRegisteredForEachTeam()
+    public function testOneRolePermissionCheckerIsRegisteredForEachTeam()
     {
         $this->container->compile();
 
         $permissionProviderForTeam1 = new Reference('team1.provider.permission');
         $permissionProviderForTeam2 = new Reference('team2.provider.permission');
 
-        $this->assertContainerBuilderHasService('team1.checker.permission', PermissionChecker::class);
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('team1.checker.permission', 0, $permissionProviderForTeam1);
+        $this->assertContainerBuilderHasService('team1.checker.role_permission', RolePermissionChecker::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('team1.checker.role_permission', 0, $permissionProviderForTeam1);
 
-        $this->assertContainerBuilderHasService('team2.checker.permission', PermissionChecker::class);
-        $this->assertContainerBuilderHasServiceDefinitionWithArgument('team2.checker.permission', 0, $permissionProviderForTeam2);
+        $this->assertContainerBuilderHasService('team2.checker.role_permission', RolePermissionChecker::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('team2.checker.role_permission', 0, $permissionProviderForTeam2);
+    }
+
+    public function testOneTeamMemberPermissionCheckerIsRegisteredForEachTeam()
+    {
+        $this->container->compile();
+
+        $rolePermissionCheckerForTeam1 = new Reference('team1.checker.role_permission');
+        $rolePermissionCheckerForTeam2 = new Reference('team2.checker.role_permission');
+
+        $this->assertContainerBuilderHasService('team1.checker.team_member_permission', TeamMemberPermissionChecker::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('team1.checker.team_member_permission', 0, $rolePermissionCheckerForTeam1);
+
+        $this->assertContainerBuilderHasService('team2.checker.team_member_permission', TeamMemberPermissionChecker::class);
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('team2.checker.team_member_permission', 0, $rolePermissionCheckerForTeam2);
     }
 }

--- a/spec/Security/Permission/RolePermissionCheckerSpec.php
+++ b/spec/Security/Permission/RolePermissionCheckerSpec.php
@@ -2,18 +2,18 @@
 
 namespace spec\Quef\TeamBundle\Security\Permission;
 
-use Quef\TeamBundle\Security\Permission\PermissionChecker;
+use Quef\TeamBundle\Security\Permission\RolePermissionChecker;
 use PhpSpec\ObjectBehavior;
 use Prophecy\Argument;
-use Quef\TeamBundle\Security\Permission\PermissionCheckerInterface;
+use Quef\TeamBundle\Security\Permission\RolePermissionCheckerInterface;
 use Quef\TeamBundle\Security\Permission\PermissionProviderInterface;
 
-class PermissionCheckerSpec extends ObjectBehavior
+class RolePermissionCheckerSpec extends ObjectBehavior
 {
     function it_is_initializable()
     {
-        $this->shouldHaveType(PermissionChecker::class);
-        $this->shouldImplement(PermissionCheckerInterface::class);
+        $this->shouldHaveType(RolePermissionChecker::class);
+        $this->shouldImplement(RolePermissionCheckerInterface::class);
     }
 
     function let(

--- a/spec/Security/Permission/TeamMemberPermissionCheckerSpec.php
+++ b/spec/Security/Permission/TeamMemberPermissionCheckerSpec.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace spec\Quef\TeamBundle\Security\Permission;
+
+use Quef\TeamBundle\Model\TeamMemberInterface;
+use Quef\TeamBundle\Security\Permission\RolePermissionCheckerInterface;
+use Quef\TeamBundle\Security\Permission\TeamMemberPermissionChecker;
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+use Quef\TeamBundle\Security\Permission\TeamMemberPermissionCheckerInterface;
+
+class TeamMemberPermissionCheckerSpec extends ObjectBehavior
+{
+    function it_is_initializable()
+    {
+        $this->shouldHaveType(TeamMemberPermissionChecker::class);
+        $this->shouldImplement(TeamMemberPermissionCheckerInterface::class);
+    }
+
+    function let(
+        RolePermissionCheckerInterface $rolePermissionChecker
+    ) {
+        $this->beConstructedWith($rolePermissionChecker);
+    }
+
+    function it_authorizes_a_team_member_if_a_permission_is_defined_for_his_role(
+        TeamMemberInterface $teamMember,
+        RolePermissionCheckerInterface $rolePermissionChecker
+    ) {
+        $teamMember->getTeamRole()->willReturn('role1');
+
+        $rolePermissionChecker->isAuthorized(Argument::type('string'), Argument::type('string'))->willReturn(true);
+
+        $this->isAuthorized($teamMember, 'permission')->shouldReturn(true);
+    }
+
+    function it_denies_a_team_member_if_a_permission_is_not_defined_for_his_role(
+        TeamMemberInterface $teamMember,
+        RolePermissionCheckerInterface $rolePermissionChecker
+    ) {
+        $teamMember->getTeamRole()->willReturn('role1');
+
+        $rolePermissionChecker->isAuthorized(Argument::type('string'), Argument::type('string'))->willReturn(false);
+
+        $this->isAuthorized($teamMember, 'permission')->shouldReturn(false);
+    }
+}


### PR DESCRIPTION
This PR will add a service to check the permissions of a team member.

The service used to check the permissions for a role has been renamed "[team].checker.role_permission.

The service used to check the permissions for a team member is named "[team].checker.team_member_permission"