### PR TITLE
Fix symfony 4 deprecation

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,8 +18,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('quef_team');
+        $treeBuilder = new TreeBuilder('quef_team');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode->children()
             ->arrayNode('teams')


### PR DESCRIPTION
Symfony 5 require to declare name when creating TreeBuilder.